### PR TITLE
Millisecond part displayed incorrectly

### DIFF
--- a/src/main/java/io/tesla/lifecycle/profiler/Timer.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/Timer.java
@@ -25,23 +25,28 @@ public class Timer {
   public static String formatTime(long ms) {
     long secs = ms / MS_PER_SEC;
     long mins = secs / SEC_PER_MIN;
-    secs = secs % SEC_PER_MIN;    
+    secs = secs % SEC_PER_MIN;
     long fractionOfASecond = ms - (secs * 1000);
-//    System.out.println("mins " + mins);
-//    System.out.println("secs " + secs);
-//    System.out.println(fractionOfASecond);
-//    System.out.println(">> " + fractionOfASecond);
-    
-    String msg = mins + "m " + secs + "." + fractionOfASecond;
 
-    if (msg.length() == 3) {
-      msg += "00s";
-    } else if (msg.length() == 4) {
-      msg += "0s";
-    } else {
-      msg += "s";
-    }
+      StringBuilder msg = new StringBuilder();
+      if (mins > 0)
+      {
+          msg.append(mins);
+          msg.append("m ");
+      }
+      if (secs > 0)
+      {
+          msg.append(secs);
+          msg.append("s");
+      }
 
-    return msg;
+      if ( mins == 0)
+      {
+          if (msg.length() > 0 ) msg.append(" ");
+          msg.append(fractionOfASecond);
+          msg.append("ms");
+      }
+
+      return msg.toString();
   }
 }

--- a/src/test/java/io/tesla/lifecycle/profiler/TimerTest.java
+++ b/src/test/java/io/tesla/lifecycle/profiler/TimerTest.java
@@ -1,0 +1,26 @@
+package io.tesla.lifecycle.profiler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.tesla.lifecycle.profiler.Timer.MS_PER_SEC;
+
+/**
+ * @author Kristian Rosenvold
+ */
+public class TimerTest {
+
+    @Test
+    public void testTimeFormats() throws Exception
+    {
+        Assert.assertEquals("1ms", Timer.formatTime(1));
+        Assert.assertEquals("1s 1ms", Timer.formatTime(1001));
+        Assert.assertEquals("1m 1s", Timer.formatTime(61 * MS_PER_SEC));
+    }
+
+    @Test
+    public void assertDetailLoss()
+    {
+        Assert.assertEquals("1m 1s", Timer.formatTime(61 * MS_PER_SEC + 1));
+    }
+}


### PR DESCRIPTION
The profiler would show 1ms as 0m 0.1s, which is plain wrong. Pimped display format and added testcase
