### PR TITLE
Update parameter name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To profile your build you need to install the profiling extension your Maven/Tes
 To active the profiling you need to enable the `profile` system property:
 
 ```
-mvn clean install -Dprofile
+mvn clean install -Dtesla.profile
 ```
 
 Here's an example of what the output will look like:


### PR DESCRIPTION
Fix for issue #4. The lack of output was due to the wrong parameter
being used. As per your response it should be 'tesla.profile' and not just 'profile'
