### PR TITLE
improve maven-profiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+.*
+!.github
+!.gitignore
+!.mvn
+*.bak
+*.log
+*.diff
+*.patch
+*.iml
 target
-.project
-.classpath
-.settings
 release.properties
+

--- a/pom.xml
+++ b/pom.xml
@@ -47,14 +47,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
-      </plugin>    
+      </plugin>
       <plugin>
         <groupId>io.tesla.maven.plugins</groupId>
         <artifactId>tesla-license-plugin</artifactId>
-      </plugin>    
+      </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>sisu-maven-plugin</artifactId>

--- a/src/main/java/io/tesla/lifecycle/profiler/AbstractProfile.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/AbstractProfile.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2012 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.tesla.lifecycle.profiler;
+
+public abstract class AbstractProfile implements Profile {
+
+  protected long elapsedTime;
+
+  protected AbstractProfile() {
+    super();
+  }
+
+  /**
+   * @param elapsedTime the new value of {@link #getElapsedTime()}.
+   */
+  public void setElapsedTime(long elapsedTime) {
+    this.elapsedTime = elapsedTime;
+  }
+
+  /**
+   * @param millis the milliseconds to add to {@link #getElapsedTime() elapsed time}.
+   */
+  public void addElapsedTime(long millis) {
+
+    this.elapsedTime += millis;
+  }
+
+  @Override
+  public long getElapsedTime() {
+      return elapsedTime;
+  }
+
+}

--- a/src/main/java/io/tesla/lifecycle/profiler/AbstractTimerProfile.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/AbstractTimerProfile.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2012 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.tesla.lifecycle.profiler;
+
+import io.tesla.lifecycle.profiler.internal.DefaultTimer;
+
+public abstract class AbstractTimerProfile extends AbstractProfile {
+
+  protected final Timer timer;
+
+  protected AbstractTimerProfile() {
+    this.timer = new DefaultTimer();
+  }
+
+  public void stop() {
+    timer.stop();
+  }
+
+  @Override
+  public long getElapsedTime() {
+    if(elapsedTime != 0) {
+      return elapsedTime;
+    }
+    return timer.getElapsedTime();
+  }
+
+}

--- a/src/main/java/io/tesla/lifecycle/profiler/AggregationProfile.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/AggregationProfile.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2012 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.tesla.lifecycle.profiler;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AggregationProfile extends AbstractProfile {
+
+  private final String name;
+
+  private final Map<String, AggregationProfile> childMap;
+
+  private final List<AggregationProfile> children;
+
+  public AggregationProfile() {
+    this("all");
+  }
+
+  public AggregationProfile(String name) {
+    super();
+    this.name = name;
+    this.childMap = new HashMap<>();
+    this.children = new ArrayList<>();
+  }
+
+  @Override
+  public String getName() {
+
+    return this.name;
+  }
+
+  @Override
+  public long getElapsedTime() {
+
+    long millis = this.elapsedTime;
+    if (millis == 0) {
+      for (AggregationProfile child : this.children) {
+        millis += child.getElapsedTime();
+      }
+    }
+    return millis;
+  }
+
+  public AggregationProfile getChild(String name) {
+
+    return this.childMap.get(name);
+  }
+
+  public AggregationProfile getOrCreateChild(String name) {
+
+    return this.childMap.computeIfAbsent(name, this::newAggregationProfile);
+  }
+
+  private AggregationProfile newAggregationProfile(String name) {
+
+    AggregationProfile profile = new AggregationProfile(name);
+    this.children.add(profile);
+    return profile;
+  }
+
+  @Override
+  public Collection<? extends Profile> getChildren() {
+
+    return this.children;
+  }
+}

--- a/src/main/java/io/tesla/lifecycle/profiler/LifecycleProfiler.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/LifecycleProfiler.java
@@ -80,9 +80,11 @@ public class LifecycleProfiler extends AbstractEventSpy {
         //
         projectProfile = new ProjectProfile(executionEvent.getProject());
       } else if (executionEvent.getType() == ExecutionEvent.Type.ProjectSucceeded || executionEvent.getType() == ExecutionEvent.Type.ProjectFailed) {
-        //
-        //
-        //
+        if (phaseProfile != null) {
+          phaseProfile.stop();
+          projectProfile.addPhaseProfile(phaseProfile);
+          phaseProfile = null;
+        }
         projectProfile.stop();
         sessionProfile.addProjectProfile(projectProfile);
       } else if (executionEvent.getType() == ExecutionEvent.Type.MojoStarted) {

--- a/src/main/java/io/tesla/lifecycle/profiler/MojoProfile.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/MojoProfile.java
@@ -7,21 +7,34 @@
  */
 package io.tesla.lifecycle.profiler;
 
-import io.tesla.lifecycle.profiler.internal.DefaultTimer;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.plugin.MojoExecution;
 
-public class MojoProfile extends Profile {
+public class MojoProfile extends AbstractTimerProfile {
 
   private MojoExecution mojoExecution;
-  
+
   protected MojoProfile(MojoExecution mojoExecution) {
-    super(new DefaultTimer());
+    super();
     this.mojoExecution = mojoExecution;
   }
-  
+
   public String getId() {
-    return mojoExecution.getGroupId() + ":" + mojoExecution.getArtifactId() + ":" + mojoExecution.getVersion() + " (" + mojoExecution.getExecutionId() + ") ";
+    return mojoExecution.getGroupId() + ":" + mojoExecution.getArtifactId() + ":" + mojoExecution.getVersion() + " (" + mojoExecution.getExecutionId() + ")";
+  }
+
+  @Override
+  public String getName() {
+
+    return getId();
+  }
+
+  @Override
+  public List<? extends Profile> getChildren() {
+
+    return Collections.emptyList();
   }
 
 }

--- a/src/main/java/io/tesla/lifecycle/profiler/PhaseProfile.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/PhaseProfile.java
@@ -7,22 +7,20 @@
  */
 package io.tesla.lifecycle.profiler;
 
-import io.tesla.lifecycle.profiler.internal.DefaultTimer;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class PhaseProfile extends Profile {
+public class PhaseProfile extends AbstractTimerProfile {
 
   private String phase;
   private List<MojoProfile> mojoProfiles;
-  
+
   public PhaseProfile(String phase) {
-    super(new DefaultTimer());
+    super();
     this.phase = phase;
     this.mojoProfiles = new ArrayList<MojoProfile>();
   }
-  
+
   public void addMojoProfile(MojoProfile mojoProfile) {
     mojoProfiles.add(mojoProfile);
   }
@@ -33,5 +31,17 @@ public class PhaseProfile extends Profile {
 
   public List<MojoProfile> getMojoProfiles() {
     return mojoProfiles;
+  }
+
+  @Override
+  public String getName() {
+
+    return phase;
+  }
+
+  @Override
+  public List<? extends Profile> getChildren() {
+
+    return getMojoProfiles();
   }
 }

--- a/src/main/java/io/tesla/lifecycle/profiler/Profile.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/Profile.java
@@ -7,29 +7,25 @@
  */
 package io.tesla.lifecycle.profiler;
 
-import io.tesla.lifecycle.profiler.internal.DefaultTimer;
+import java.util.Collection;
+import java.util.List;
 
-public class Profile {
-  
-  protected long elapsedTime;
-  protected Timer timer;
-    
-  protected Profile(DefaultTimer timer) {
-    this.timer = timer;    
-  }
-    
-  public void stop() {
-    timer.stop();
-  }
-  
-  void setElapsedTime(long elapsedTime) {
-    this.elapsedTime = elapsedTime;
-  }
-  
-  public long getElapsedTime() {
-    if(elapsedTime != 0) {
-      return elapsedTime;
-    }
-    return timer.getTime();
-  }
+/**
+ * Interface for a profile of the profiling. The root profile is {@link SessionProfile} representing the recording of the
+ * entire session. Each {@link Profile} can have {@link #getChildren() children} representing a partition of the whole
+ * into smaller steps to give more details and granularity to trace down leaks and find spots worth to optimize.
+ */
+public interface Profile extends Timing {
+
+  /**
+   * @return the name of this profile (name of e.g. maven project, phase, plugin).
+   */
+  String getName();
+
+  /**
+   * @return the {@link List} of child {@link Profile}s contained in this {@link Profile}. Will be an empty list if this
+   *         profile has not children.
+   */
+  Collection<? extends Profile> getChildren();
+
 }

--- a/src/main/java/io/tesla/lifecycle/profiler/ProjectProfile.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/ProjectProfile.java
@@ -7,24 +7,22 @@
  */
 package io.tesla.lifecycle.profiler;
 
-import io.tesla.lifecycle.profiler.internal.DefaultTimer;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.project.MavenProject;
 
-public class ProjectProfile extends Profile {
+public class ProjectProfile extends AbstractTimerProfile {
 
   private MavenProject project;
   private List<PhaseProfile> phaseProfiles;
-  
+
   public ProjectProfile(MavenProject project) {
-    super(new DefaultTimer());
+    super();
     this.project = project;
     this.phaseProfiles = new ArrayList<PhaseProfile>();
   }
-  
+
   public void addPhaseProfile(PhaseProfile phaseProfile) {
     phaseProfiles.add(phaseProfile);
   }
@@ -35,5 +33,17 @@ public class ProjectProfile extends Profile {
 
   public List<PhaseProfile> getPhaseProfile() {
     return phaseProfiles;
+  }
+
+  @Override
+  public String getName() {
+
+    return getProjectName();
+  }
+
+  @Override
+  public List<? extends Profile> getChildren() {
+
+    return getPhaseProfile();
   }
 }

--- a/src/main/java/io/tesla/lifecycle/profiler/SessionProfile.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/SessionProfile.java
@@ -7,25 +7,38 @@
  */
 package io.tesla.lifecycle.profiler;
 
-import io.tesla.lifecycle.profiler.internal.DefaultTimer;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class SessionProfile extends Profile {
+public class SessionProfile extends AbstractTimerProfile {
+
+  private final String name;
 
   private List<ProjectProfile> projectProfiles;
-  
-  public SessionProfile() {
-    super(new DefaultTimer());
-    this.projectProfiles = new ArrayList<ProjectProfile>();
+
+  public SessionProfile(String name) {
+    super();
+    this.name = name;
+    this.projectProfiles = new ArrayList<>();
   }
-  
+
   public void addProjectProfile(ProjectProfile projectProfile) {
     projectProfiles.add(projectProfile);
   }
 
   public List<ProjectProfile> getProjectProfiles() {
     return projectProfiles;
+  }
+
+  @Override
+  public String getName() {
+
+    return this.name;
+  }
+
+  @Override
+  public List<? extends Profile> getChildren() {
+
+    return getProjectProfiles();
   }
 }

--- a/src/main/java/io/tesla/lifecycle/profiler/Timing.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/Timing.java
@@ -8,15 +8,15 @@
 package io.tesla.lifecycle.profiler;
 
 /**
- * Interface for a simple timer that is like a stop-watch. Once created, it starts ticking until you {@link #stop() stop} it.
- * Then you can use {@link #getElapsedTime()} to retrieve the elapsed duration.
+ * Interface for an object that records the timing and therefore has an {@link #getElapsedTime() elapsed time}.
  */
-public interface Timer extends Timing {
+public interface Timing {
 
   /**
-   * Stops this timer. Should only be called once.
+   * @return the duration in milliseconds of this timing. Typically the duration from the instantiation a {@link Timer}
+   *         until it has been {@link Timer#stop() stop}ed.
    */
-  void stop();
+  long getElapsedTime();
 
 //  default Duration getDuration() {
 //

--- a/src/main/java/io/tesla/lifecycle/profiler/internal/AbstractSessionProfileRenderer.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/internal/AbstractSessionProfileRenderer.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2012 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.tesla.lifecycle.profiler.internal;
+
+import java.util.Locale;
+
+import io.tesla.lifecycle.profiler.SessionProfileRenderer;
+
+/**
+ * Abstract base implementation of {@link SessionProfileRenderer}.
+ */
+public abstract class AbstractSessionProfileRenderer implements SessionProfileRenderer {
+
+  /** Determines if the profiling report shall be logged at the end of the build */
+  protected final boolean logProfileData;
+
+  /**
+   * The constructor.
+   */
+  public AbstractSessionProfileRenderer() {
+
+    super();
+    this.logProfileData = getBooleanProperty("maven.profile.log.output", true);
+  }
+
+  /**
+   * @param name the name of the {@link System#getProperty(String) system property}.
+   * @param defaultValue the default value if the {@link System#getProperty(String) system property} is undefined or invalid.
+   * @return the configured boolean value.
+   */
+  protected static boolean getBooleanProperty(String name, boolean defaultValue) {
+
+    boolean result = defaultValue;
+    String valueAsString = System.getProperty(name);
+    if (valueAsString != null) {
+      valueAsString = valueAsString.toLowerCase(Locale.ROOT);
+      if ("true".equals(valueAsString) || "yes".equals(valueAsString)) {
+        result = true;
+      } else if ("false".equals(valueAsString) || "no".equals(valueAsString)) {
+        result = true;
+      }
+    }
+    return result;
+  }
+
+}

--- a/src/main/java/io/tesla/lifecycle/profiler/internal/AdvancedSessionProfileRenderer.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/internal/AdvancedSessionProfileRenderer.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2012 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.tesla.lifecycle.profiler.internal;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import io.tesla.lifecycle.profiler.AggregationProfile;
+import io.tesla.lifecycle.profiler.Profile;
+import io.tesla.lifecycle.profiler.SessionProfile;
+
+/**
+ * Advanced implementation of {@link AbstractSessionProfileRenderer} that can write both CSV and/or log human readable profiling summary.
+ */
+@Named
+@Singleton
+public class AdvancedSessionProfileRenderer extends AbstractSessionProfileRenderer {
+
+  private final static String WRITE_CSV = "maven.profile.write.csv";
+
+  private static final char CSV_SEPARATOR = ';';
+
+  private final List<AggregationProfile> aggregations;
+
+  private Writer csvWriter;
+
+  public AdvancedSessionProfileRenderer() {
+
+    super();
+    this.aggregations = new ArrayList<>();
+    this.aggregations.add(new AggregationProfile("Aggregation by project"));
+    this.aggregations.add(new AggregationProfile("Aggregation by phase"));
+    this.aggregations.add(new AggregationProfile("Aggregation by mojo"));
+  }
+
+  public void render(SessionProfile sessionProfile) {
+
+    boolean writeCsv = getBooleanProperty(WRITE_CSV, true);
+    OutputStream out = null;
+    if (writeCsv) {
+      String timestamp = new DateTimeFormatterBuilder().appendPattern("YYYY-MM-dd_HH-mm-ss").toFormatter()
+          .format(LocalDateTime.now());
+      String filename = ".maven.profiling." + timestamp + ".csv";
+      try {
+        out = new FileOutputStream(filename);
+        this.csvWriter = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+        try {
+          this.csvWriter.write("Depth");
+          this.csvWriter.write(CSV_SEPARATOR);
+          this.csvWriter.write("Name");
+          this.csvWriter.write(CSV_SEPARATOR);
+          this.csvWriter.write("Duration (ms)");
+          this.csvWriter.write(CSV_SEPARATOR);
+          this.csvWriter.write("Fraction");
+          this.csvWriter.write("\n");
+        } catch (IOException e) {
+          throw new IllegalStateException("Failed to write CSV data!", e);
+        }
+      } catch (IOException e) {
+        throw new IllegalStateException("Failed to open file '" + filename + "' for writing!", e);
+      }
+    }
+    try {
+      renderProfile(sessionProfile, true);
+      for (AggregationProfile aggregation : this.aggregations) {
+        aggregation.setElapsedTime(sessionProfile.getElapsedTime());
+        renderProfile(aggregation, false);
+      }
+    } finally {
+      if (writeCsv) {
+        close(this.csvWriter);
+        this.csvWriter = null;
+        close(out);
+      }
+    }
+  }
+
+  private void renderProfile(Profile sessionProfile, boolean aggregate) {
+
+    renderProfile(0, sessionProfile, 0, "");
+    renderProfileRecursive(sessionProfile, 0, "", aggregate);
+  }
+
+  private void close(AutoCloseable out) {
+
+    if (out != null) {
+      try {
+        out.close();
+      } catch (Exception e) {
+        // ignore
+      }
+    }
+  }
+
+  private void renderProfileRecursive(Profile profile, int depth, String prefix, boolean aggregate) {
+
+    Collection<? extends Profile> children = profile.getChildren();
+    AggregationProfile aggregation = null;
+    if (aggregate && (depth < aggregations.size())) {
+      aggregation = this.aggregations.get(depth);
+    }
+    int childDepth = depth + 1;
+    long duration = profile.getElapsedTime();
+    String childPrefix = prefix + "  ";
+    for (Profile child : children) {
+      renderProfile(childDepth, child, duration, childPrefix);
+      if (aggregation != null) {
+        aggregation.getOrCreateChild(child.getName()).addElapsedTime(child.getElapsedTime());
+      }
+      renderProfileRecursive(child, childDepth, childPrefix, aggregate);
+    }
+  }
+
+  private void renderProfile(int depth, Profile profile, long total, String prefix) {
+
+    String fraction = "1";
+    String percentage = "100%";
+    if (total > 0) {
+      long duration = profile.getElapsedTime();
+      if (duration < total) {
+        long fract = (duration * 1000) / total;
+        percentage = (fract / 10) + "%";
+        fraction = Long.toString(fract);
+        int zeros = 3 - fraction.length();
+        while (zeros > 0) {
+          fraction = "0" + fraction;
+          zeros--;
+        }
+        fraction = "0." + fraction;
+      } else if (duration > total) {
+        // invalid, should never happen
+        fraction = "";
+        percentage = "";
+      }
+    }
+    renderProfileAsCsv(depth, profile, fraction);
+    if (this.logProfileData) {
+      String message = prefix + profile.getName() + " " + DefaultTimer.formatMilliseconds(profile.getElapsedTime())
+          + "(" + percentage + ")";
+      render(message);
+    }
+  }
+
+  private void renderProfileAsCsv(int depth, Profile profile, String fraction) {
+
+    if (this.csvWriter == null) {
+      return;
+    }
+    try {
+      this.csvWriter.write(Integer.toString(depth));
+      this.csvWriter.write(CSV_SEPARATOR);
+      this.csvWriter.write(profile.getName());
+      this.csvWriter.write(CSV_SEPARATOR);
+      this.csvWriter.write(Long.toString(profile.getElapsedTime()));
+      this.csvWriter.write(CSV_SEPARATOR);
+      this.csvWriter.write(fraction);
+      this.csvWriter.write("\n");
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to write CSV data!", e);
+    }
+  }
+
+  private void render(String s) {
+
+    System.out.println(s);
+  }
+}

--- a/src/main/java/io/tesla/lifecycle/profiler/internal/DefaultSessionProfileRenderer.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/internal/DefaultSessionProfileRenderer.java
@@ -11,40 +11,35 @@ import io.tesla.lifecycle.profiler.MojoProfile;
 import io.tesla.lifecycle.profiler.PhaseProfile;
 import io.tesla.lifecycle.profiler.ProjectProfile;
 import io.tesla.lifecycle.profiler.SessionProfile;
-import io.tesla.lifecycle.profiler.SessionProfileRenderer;
-import io.tesla.lifecycle.profiler.Timer;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
+// old implementation that has been replaced by AdvancedSessionProfileRenderer. Could actually be removed.
+//@Named
+//@Singleton
+public class DefaultSessionProfileRenderer extends AbstractSessionProfileRenderer {
 
-@Named
-@Singleton
-public class DefaultSessionProfileRenderer implements SessionProfileRenderer {
-
-  private Timer timer;
-  
-  @Inject
-  public DefaultSessionProfileRenderer(Timer timer) {
-    this.timer = timer;
+  public DefaultSessionProfileRenderer() {
+    super();
   }
-  
+
   public void render(SessionProfile sessionProfile) {
-    
+
+    if (!this.logProfileData) {
+      return;
+    }
     for(ProjectProfile pp : sessionProfile.getProjectProfiles()) {
       render("");
       render(pp.getProjectName());
       render("");
       for(PhaseProfile phaseProfile : pp.getPhaseProfile()) {
-        render("  " + phaseProfile.getPhase() + " " + timer.format(phaseProfile.getElapsedTime()));
+        render("  " + phaseProfile.getPhase() + " " + DefaultTimer.formatMilliseconds(phaseProfile.getElapsedTime()));
         for(MojoProfile mp : phaseProfile.getMojoProfiles()) {
-          render("    " + mp.getId() + timer.format(mp.getElapsedTime())); 
+          render("    " + mp.getId() + DefaultTimer.formatMilliseconds(mp.getElapsedTime()));
         }
         render("");
       }
     }
   }
-  
+
   private void render(String s) {
     System.out.println(s);
   }

--- a/src/main/java/io/tesla/lifecycle/profiler/internal/DefaultTimer.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/internal/DefaultTimer.java
@@ -7,17 +7,17 @@
  */
 package io.tesla.lifecycle.profiler.internal;
 
-import io.tesla.lifecycle.profiler.Timer;
-
 import javax.inject.Named;
 import javax.inject.Singleton;
+
+import io.tesla.lifecycle.profiler.Timer;
 
 @Named
 @Singleton
 public class DefaultTimer implements Timer {
-  
-  public static final int MS_PER_SEC = 1000;
-  public static final int SEC_PER_MIN = 60;
+  static final int MS_PER_SEC = 1000;
+  static final int SEC_PER_MIN = 60;
+
   private long start;
   private long time;
 
@@ -25,11 +25,13 @@ public class DefaultTimer implements Timer {
     start = System.currentTimeMillis();
   }
 
+  @Override
   public void stop() {
     time = elapsedTime();
   }
 
-  public long getTime() {
+  @Override
+  public long getElapsedTime() {
     return time;
   }
 
@@ -37,11 +39,12 @@ public class DefaultTimer implements Timer {
     return System.currentTimeMillis() - start;
   }
 
-  public String format(long ms) {
-    long secs = ms / MS_PER_SEC;
+  protected static String formatMilliseconds(long durationInMillis) {
+
+    long secs = durationInMillis / MS_PER_SEC;
     long mins = secs / SEC_PER_MIN;
     secs = secs % SEC_PER_MIN;
-    long fractionOfASecond = ms - (secs * 1000);
+    long fractionOfASecond = durationInMillis - (secs * 1000);
 
     StringBuilder msg = new StringBuilder();
     if (mins > 0) {
@@ -62,4 +65,5 @@ public class DefaultTimer implements Timer {
 
     return msg.toString();
   }
+
 }

--- a/src/test/java/io/tesla/lifecycle/profiler/LifecycleProfilerTest.java
+++ b/src/test/java/io/tesla/lifecycle/profiler/LifecycleProfilerTest.java
@@ -21,7 +21,7 @@ public class LifecycleProfilerTest extends InjectedTestCase {
 
   public void testSessionProfile() {
 
-    SessionProfile s = new SessionProfile();
+    SessionProfile s = new SessionProfile("mvn");
 
     ProjectProfile p0 = new ProjectProfile(project("g0", "a0", "v0"));
     PhaseProfile ph0 = new PhaseProfile("phase0");

--- a/src/test/java/io/tesla/lifecycle/profiler/internal/TimerTest.java
+++ b/src/test/java/io/tesla/lifecycle/profiler/internal/TimerTest.java
@@ -5,14 +5,12 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package io.tesla.lifecycle.profiler;
+package io.tesla.lifecycle.profiler.internal;
 
-import io.tesla.lifecycle.profiler.internal.DefaultTimer;
+import static io.tesla.lifecycle.profiler.internal.DefaultTimer.MS_PER_SEC;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import static io.tesla.lifecycle.profiler.internal.DefaultTimer.MS_PER_SEC;
 
 /**
  * @author Kristian Rosenvold
@@ -22,15 +20,13 @@ public class TimerTest {
   @Test
   public void testTimeFormats() throws Exception {
 
-    Timer timer = new DefaultTimer();
-    Assert.assertEquals("1ms", timer.format(1));
-    Assert.assertEquals("1s 1ms", timer.format(1001));
-    Assert.assertEquals("1m 1s", timer.format(61 * MS_PER_SEC));
+    Assert.assertEquals("1ms", DefaultTimer.formatMilliseconds(1));
+    Assert.assertEquals("1s 1ms", DefaultTimer.formatMilliseconds(1001));
+    Assert.assertEquals("1m 1s", DefaultTimer.formatMilliseconds(61 * MS_PER_SEC));
   }
 
   @Test
   public void assertDetailLoss() {
-    Timer timer = new DefaultTimer();
-    Assert.assertEquals("1m 1s", timer.format(61 * MS_PER_SEC + 1));
+    Assert.assertEquals("1m 1s", DefaultTimer.formatMilliseconds(61 * MS_PER_SEC + 1));
   }
 }


### PR DESCRIPTION
First of all thanks for creating the maven extension.
It was a great starting point to solve my problems analyzing huge, complex and slow maven builds.
However, I needed various improvements especially it was important to have better support for semi-automatic post-processing of the collected data (as CSV that can be imported to a spreadsheet app like Excel and render pie diagrams, etc.). 

improvements:
* do nothing unless `-Dmaven.profile` is set (avoid causing overhead if not activated).
* write CSV file (can be disabled via `-Dmaven.profile.write.csv=false`
* ability to disable logging the result via `-Dmaven.profile.log.output=false`
* perform aggregations (build time per module/per phase/per MOJO)
* report percentages in log output and as fractions for CSV
* upgrade to Java 1.8 (everything before that is long dead, users can still use `0.0.3` if they think that Java 1.5 is still secure and should be used)
* added some JavaDoc

With these changes the extension becomes IMHO quite useful.