### PR TITLE
Make Maven profiling parallel-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ To activate the profiling you need to enable the `maven.profile` system property
 mvn clean install -Dmaven.profile
 ```
 
+Parallel Maven reactors are supported. Project, phase, and mojo state is isolated by project when Maven executes modules concurrently with `-T`.
+
+### Raw timeline
+
+Set `maven.profile.timeline` to record the raw Maven execution timeline as JSON Lines. The timeline can be enabled with or without the aggregate console/CSV profile:
+
+```
+mvn -T4 verify -Dmaven.profile -Dmaven.profile.timeline
+mvn -T4 verify -Dmaven.profile.timeline=target/maven-timeline.jsonl
+```
+
+An empty value or `true` writes `.maven.profiling-timeline.jsonl` in the multi-module project directory. A non-boolean value is used as the output path. Each record contains a schema version, sequence, wall and monotonic timestamps, event type, Maven thread, and applicable project/mojo identity. Session startup also records the selected reactor projects and their upstream project dependencies.
+
+The timeline contains observed Maven session, project, and mojo start/finish events. Maven does not emit a project-ready or scheduler-queue event; tools may derive an earliest-ready bound from the captured dependency graph and predecessor completion times, but should label that value as derived.
+
 Here's an example of what the output will look like:
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -84,4 +84,71 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <configuration combine.self="override">
+            <java>
+              <removeUnusedImports />
+              <importOrder />
+            </java>
+            <pom>
+              <sortPom>
+                <expandEmptyElements>false</expandEmptyElements>
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+              </sortPom>
+            </pom>
+            <upToDateChecking>
+              <enabled>true</enabled>
+            </upToDateChecking>
+          </configuration>
+          <executions>
+            <execution>
+              <id>default</id>
+              <configuration combine.self="override">
+                <java>
+                  <removeUnusedImports />
+                  <importOrder />
+                </java>
+                <pom>
+                  <sortPom>
+                    <expandEmptyElements>false</expandEmptyElements>
+                    <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+                  </sortPom>
+                </pom>
+                <upToDateChecking>
+                  <enabled>true</enabled>
+                </upToDateChecking>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration combine.self="override">
+          <java>
+            <removeUnusedImports />
+            <importOrder />
+          </java>
+          <pom>
+            <sortPom>
+              <expandEmptyElements>false</expandEmptyElements>
+              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+            </sortPom>
+          </pom>
+          <upToDateChecking>
+            <enabled>true</enabled>
+          </upToDateChecking>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/java/io/tesla/lifecycle/profiler/LifecycleProfiler.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/LifecycleProfiler.java
@@ -7,11 +7,18 @@
  */
 package io.tesla.lifecycle.profiler;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.maven.eventspy.AbstractEventSpy;
 import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.project.MavenProject;
 
 // pom deserialization
 // app dependency download
@@ -28,26 +35,34 @@ public class LifecycleProfiler extends AbstractEventSpy {
     private static final String MAVEN_PROFILE = "maven.profile";
 
     private final SessionProfileRenderer renderer;
+    private final TimelineRecorder timelineRecorder;
 
+    private final boolean profileEnabled;
     private final boolean disabled;
 
     //
     // Profile data
     //
-    private SessionProfile sessionProfile;
-    private ProjectProfile projectProfile;
-    private PhaseProfile phaseProfile;
-    private MojoProfile mojoProfile;
+    private volatile SessionProfile sessionProfile;
+    private final Map<MavenProject, ProjectProfileState> projectProfiles = new ConcurrentHashMap<>();
 
     @Inject
     public LifecycleProfiler(SessionProfileRenderer sessionProfileRenderer) {
+        this(sessionProfileRenderer, new TimelineRecorder());
+    }
+
+    LifecycleProfiler(SessionProfileRenderer sessionProfileRenderer, TimelineRecorder timelineRecorder) {
         super();
         this.renderer = sessionProfileRenderer;
-        this.disabled = (System.getProperty(MAVEN_PROFILE) == null);
+        this.timelineRecorder = timelineRecorder;
+        this.profileEnabled = (System.getProperty(MAVEN_PROFILE) != null);
+        this.disabled = !profileEnabled && !timelineRecorder.isEnabled();
     }
 
     @Override
-    public void init(Context context) throws Exception {}
+    public void init(Context context) throws Exception {
+        timelineRecorder.init();
+    }
 
     @Override
     public void onEvent(Object event) throws Exception {
@@ -56,6 +71,10 @@ public class LifecycleProfiler extends AbstractEventSpy {
         }
         if (event instanceof ExecutionEvent) {
             ExecutionEvent executionEvent = (ExecutionEvent) event;
+            timelineRecorder.record(executionEvent);
+            if (!profileEnabled) {
+                return;
+            }
             if (executionEvent.getType() == ExecutionEvent.Type.SessionStarted) {
                 //
                 //
@@ -66,46 +85,100 @@ public class LifecycleProfiler extends AbstractEventSpy {
                     command.append(goal);
                 }
                 sessionProfile = new SessionProfile(command.toString());
+                projectProfiles.clear();
             } else if (executionEvent.getType() == ExecutionEvent.Type.SessionEnded) {
                 //
                 //
                 //
-                sessionProfile.stop();
-                renderer.render(sessionProfile);
+                finishSession(executionEvent);
             } else if (executionEvent.getType() == ExecutionEvent.Type.ProjectStarted) {
                 //
                 // We need to collect the mojoExecutions within each project
                 //
-                projectProfile = new ProjectProfile(executionEvent.getProject());
+                projectProfiles.put(executionEvent.getProject(), new ProjectProfileState(executionEvent.getProject()));
             } else if (executionEvent.getType() == ExecutionEvent.Type.ProjectSucceeded
                     || executionEvent.getType() == ExecutionEvent.Type.ProjectFailed) {
-                if (phaseProfile != null) {
-                    phaseProfile.stop();
-                    projectProfile.addPhaseProfile(phaseProfile);
-                    phaseProfile = null;
-                }
-                projectProfile.stop();
-                sessionProfile.addProjectProfile(projectProfile);
+                projectState(executionEvent).finish();
             } else if (executionEvent.getType() == ExecutionEvent.Type.MojoStarted) {
-                String phase = executionEvent.getMojoExecution().getLifecyclePhase();
-                //
-                // Create a new phase profile if one doesn't exist or the phase has changed.
-                //
-                if (phaseProfile == null) {
-                    phaseProfile = new PhaseProfile(phase);
-                } else if (!phaseProfile.getPhase().equals(phase)) {
-                    phaseProfile.stop();
-                    projectProfile.addPhaseProfile(phaseProfile);
-                    phaseProfile = new PhaseProfile(phase);
-                }
-                mojoProfile = new MojoProfile(executionEvent.getMojoExecution());
+                projectState(executionEvent).mojoStarted(executionEvent);
             } else if (executionEvent.getType() == ExecutionEvent.Type.MojoSucceeded
                     || executionEvent.getType() == ExecutionEvent.Type.MojoFailed) {
-                //
-                //
-                //
+                projectState(executionEvent).mojoFinished();
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        timelineRecorder.close();
+    }
+
+    private ProjectProfileState projectState(ExecutionEvent event) {
+        return projectProfiles.computeIfAbsent(event.getProject(), ProjectProfileState::new);
+    }
+
+    private void finishSession(ExecutionEvent event) {
+        sessionProfile.stop();
+        for (MavenProject project : event.getSession().getProjects()) {
+            ProjectProfileState state = projectProfiles.remove(project);
+            if (state != null) {
+                state.finish();
+                sessionProfile.addProjectProfile(state.projectProfile);
+            }
+        }
+
+        List<ProjectProfileState> remaining = new ArrayList<>(projectProfiles.values());
+        remaining.sort(Comparator.comparing(state -> state.projectProfile.getProjectName()));
+        for (ProjectProfileState state : remaining) {
+            state.finish();
+            sessionProfile.addProjectProfile(state.projectProfile);
+        }
+        projectProfiles.clear();
+        renderer.render(sessionProfile);
+    }
+
+    private static final class ProjectProfileState {
+        private final ProjectProfile projectProfile;
+        private PhaseProfile phaseProfile;
+        private MojoProfile mojoProfile;
+        private boolean finished;
+
+        private ProjectProfileState(MavenProject project) {
+            projectProfile = new ProjectProfile(project);
+        }
+
+        private synchronized void mojoStarted(ExecutionEvent event) {
+            String phase = event.getMojoExecution().getLifecyclePhase();
+            if (phaseProfile == null || !Objects.equals(phaseProfile.getPhase(), phase)) {
+                finishPhase();
+                phaseProfile = new PhaseProfile(phase);
+            }
+            mojoProfile = new MojoProfile(event.getMojoExecution());
+        }
+
+        private synchronized void mojoFinished() {
+            if (mojoProfile != null && phaseProfile != null) {
                 mojoProfile.stop();
                 phaseProfile.addMojoProfile(mojoProfile);
+                mojoProfile = null;
+            }
+        }
+
+        private synchronized void finish() {
+            if (finished) {
+                return;
+            }
+            mojoFinished();
+            finishPhase();
+            projectProfile.stop();
+            finished = true;
+        }
+
+        private void finishPhase() {
+            if (phaseProfile != null) {
+                phaseProfile.stop();
+                projectProfile.addPhaseProfile(phaseProfile);
+                phaseProfile = null;
             }
         }
     }

--- a/src/main/java/io/tesla/lifecycle/profiler/TimelineRecorder.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/TimelineRecorder.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) 2012 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.tesla.lifecycle.profiler;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+
+final class TimelineRecorder implements AutoCloseable {
+
+    static final String TIMELINE_PROPERTY = "maven.profile.timeline";
+    private static final String DEFAULT_TIMELINE = ".maven.profiling-timeline.jsonl";
+    private static final int SCHEMA_VERSION = 1;
+
+    private final Path output;
+    private final AtomicLong sequence = new AtomicLong();
+    private BufferedWriter writer;
+
+    TimelineRecorder() {
+        this(configuredOutput());
+    }
+
+    TimelineRecorder(Path output) {
+        this.output = output;
+    }
+
+    boolean isEnabled() {
+        return output != null;
+    }
+
+    void init() throws IOException {
+        if (!isEnabled()) {
+            return;
+        }
+        Path parent = output.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        writer = Files.newBufferedWriter(
+                output,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE);
+    }
+
+    synchronized void record(ExecutionEvent event) throws IOException {
+        if (writer == null) {
+            return;
+        }
+        writeExecutionEvent(event);
+        if (event.getType() == ExecutionEvent.Type.SessionStarted) {
+            writeReactor(event.getSession());
+        }
+        if (event.getType() == ExecutionEvent.Type.ProjectSucceeded
+                || event.getType() == ExecutionEvent.Type.ProjectFailed
+                || event.getType() == ExecutionEvent.Type.SessionEnded) {
+            writer.flush();
+        }
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        if (writer != null) {
+            writer.close();
+            writer = null;
+        }
+    }
+
+    private void writeExecutionEvent(ExecutionEvent event) throws IOException {
+        StringBuilder line = startLine("execution");
+        field(line, "event", event.getType().name());
+        field(line, "thread", Thread.currentThread().getName());
+        numberField(line, "threadId", Thread.currentThread().getId());
+        projectFields(line, event.getProject());
+        mojoFields(line, event.getMojoExecution());
+        if (event.getException() != null) {
+            field(line, "exceptionClass", event.getException().getClass().getName());
+            field(line, "exceptionMessage", event.getException().getMessage());
+        }
+        finishLine(line);
+    }
+
+    private void writeReactor(MavenSession session) throws IOException {
+        ProjectDependencyGraph graph = session.getProjectDependencyGraph();
+        for (MavenProject project : session.getProjects()) {
+            StringBuilder line = startLine("reactorProject");
+            projectFields(line, project);
+            List<MavenProject> upstream =
+                    graph == null ? Collections.emptyList() : graph.getUpstreamProjects(project, false);
+            projectArrayField(line, "upstreamProjects", upstream);
+            finishLine(line);
+        }
+    }
+
+    private StringBuilder startLine(String type) {
+        StringBuilder line = new StringBuilder(256);
+        line.append('{');
+        numberField(line, "schemaVersion", SCHEMA_VERSION);
+        field(line, "type", type);
+        numberField(line, "sequence", sequence.incrementAndGet());
+        field(line, "wallTime", Instant.now().toString());
+        numberField(line, "nanoTime", System.nanoTime());
+        return line;
+    }
+
+    private void projectFields(StringBuilder line, MavenProject project) {
+        if (project == null) {
+            return;
+        }
+        field(line, "project", projectId(project));
+        if (project.getBasedir() != null) {
+            field(line, "basedir", project.getBasedir().getAbsolutePath());
+        }
+    }
+
+    private void mojoFields(StringBuilder line, MojoExecution mojo) {
+        if (mojo == null) {
+            return;
+        }
+        field(line, "mojo", mojo.getGroupId() + ":" + mojo.getArtifactId() + ":" + mojo.getVersion());
+        field(line, "goal", mojo.getGoal());
+        field(line, "executionId", mojo.getExecutionId());
+        field(line, "lifecyclePhase", mojo.getLifecyclePhase());
+    }
+
+    private void projectArrayField(StringBuilder line, String name, List<MavenProject> projects) {
+        comma(line);
+        quote(line, name);
+        line.append(':').append('[');
+        boolean first = true;
+        for (MavenProject project : projects) {
+            if (!first) {
+                line.append(',');
+            }
+            quote(line, projectId(project));
+            first = false;
+        }
+        line.append(']');
+    }
+
+    private void finishLine(StringBuilder line) throws IOException {
+        writer.write(line.append('}').append('\n').toString());
+    }
+
+    private static String projectId(MavenProject project) {
+        return project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+    }
+
+    private static void field(StringBuilder line, String name, String value) {
+        if (value == null) {
+            return;
+        }
+        comma(line);
+        quote(line, name);
+        line.append(':');
+        quote(line, value);
+    }
+
+    private static void numberField(StringBuilder line, String name, long value) {
+        comma(line);
+        quote(line, name);
+        line.append(':').append(value);
+    }
+
+    private static void comma(StringBuilder line) {
+        if (line.length() > 1) {
+            line.append(',');
+        }
+    }
+
+    private static void quote(StringBuilder line, String value) {
+        line.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            switch (character) {
+                case '"':
+                    line.append("\\\"");
+                    break;
+                case '\\':
+                    line.append("\\\\");
+                    break;
+                case '\b':
+                    line.append("\\b");
+                    break;
+                case '\f':
+                    line.append("\\f");
+                    break;
+                case '\n':
+                    line.append("\\n");
+                    break;
+                case '\r':
+                    line.append("\\r");
+                    break;
+                case '\t':
+                    line.append("\\t");
+                    break;
+                default:
+                    if (character < 0x20) {
+                        line.append(String.format("\\u%04x", (int) character));
+                    } else {
+                        line.append(character);
+                    }
+            }
+        }
+        line.append('"');
+    }
+
+    private static Path configuredOutput() {
+        String configured = System.getProperty(TIMELINE_PROPERTY);
+        if (configured == null) {
+            return null;
+        }
+        if ("false".equalsIgnoreCase(configured) || "no".equalsIgnoreCase(configured)) {
+            return null;
+        }
+        if (configured.isEmpty() || "true".equalsIgnoreCase(configured)) {
+            String root = System.getProperty("maven.multiModuleProjectDirectory", ".");
+            return Paths.get(root, DEFAULT_TIMELINE);
+        }
+        return Paths.get(configured);
+    }
+}

--- a/src/main/java/io/tesla/lifecycle/profiler/internal/AbstractSessionProfileRenderer.java
+++ b/src/main/java/io/tesla/lifecycle/profiler/internal/AbstractSessionProfileRenderer.java
@@ -41,7 +41,7 @@ public abstract class AbstractSessionProfileRenderer implements SessionProfileRe
             if ("true".equals(valueAsString) || "yes".equals(valueAsString)) {
                 result = true;
             } else if ("false".equals(valueAsString) || "no".equals(valueAsString)) {
-                result = true;
+                result = false;
             }
         }
         return result;

--- a/src/test/java/io/tesla/lifecycle/profiler/LifecycleProfilerTest.java
+++ b/src/test/java/io/tesla/lifecycle/profiler/LifecycleProfilerTest.java
@@ -7,7 +7,22 @@
  */
 package io.tesla.lifecycle.profiler;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import javax.inject.Inject;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -52,6 +67,98 @@ public class LifecycleProfilerTest extends InjectedTestCase {
         sessionProfileRenderer.render(s);
     }
 
+    public void testParallelProjectsKeepIndependentProfiles() throws Exception {
+        String oldProfile = System.getProperty("maven.profile");
+        System.setProperty("maven.profile", "true");
+        try {
+            CapturingRenderer renderer = new CapturingRenderer();
+            LifecycleProfiler profiler = new LifecycleProfiler(renderer);
+            MavenProject firstProject = project("g", "first", "1");
+            MavenProject secondProject = project("g", "second", "1");
+            MavenSession session = session(firstProject, secondProject);
+            profiler.onEvent(event(ExecutionEvent.Type.SessionStarted, session, null, null));
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            try {
+                Future<?> first = executor.submit(() -> profileProject(
+                        profiler,
+                        session,
+                        firstProject,
+                        mojoExecution("first-goal", "first-execution", "test"),
+                        barrier));
+                Future<?> second = executor.submit(() -> profileProject(
+                        profiler,
+                        session,
+                        secondProject,
+                        mojoExecution("second-goal", "second-execution", "integration-test"),
+                        barrier));
+                first.get();
+                second.get();
+            } finally {
+                executor.shutdownNow();
+            }
+
+            profiler.onEvent(event(ExecutionEvent.Type.SessionEnded, session, null, null));
+
+            assertNotNull(renderer.profile);
+            assertEquals(2, renderer.profile.getProjectProfiles().size());
+            assertProjectProfile(renderer.profile.getProjectProfiles().get(0), "g:first:1", "test", "first-execution");
+            assertProjectProfile(
+                    renderer.profile.getProjectProfiles().get(1), "g:second:1", "integration-test", "second-execution");
+        } finally {
+            restoreProperty("maven.profile", oldProfile);
+        }
+    }
+
+    public void testTimelineRecordsRawEventsAndReactorDependenciesWithoutAggregateProfile() throws Exception {
+        String oldProfile = System.getProperty("maven.profile");
+        System.clearProperty("maven.profile");
+        Path timeline = Files.createTempFile("maven-profiler-timeline", ".jsonl");
+        try {
+            CapturingRenderer renderer = new CapturingRenderer();
+            LifecycleProfiler profiler = new LifecycleProfiler(renderer, new TimelineRecorder(timeline));
+            MavenProject firstProject = project("g", "first", "1");
+            MavenProject secondProject = project("g", "second", "1");
+            MavenSession session = session(firstProject, secondProject);
+            session.setProjectDependencyGraph(graph(firstProject, secondProject));
+            MojoExecution mojo = mojoExecution("test", "default-test", "test");
+
+            profiler.init(null);
+            profiler.onEvent(event(ExecutionEvent.Type.SessionStarted, session, null, null));
+            profiler.onEvent(event(ExecutionEvent.Type.ProjectStarted, session, secondProject, null));
+            profiler.onEvent(event(ExecutionEvent.Type.MojoStarted, session, secondProject, mojo));
+            profiler.onEvent(event(ExecutionEvent.Type.MojoSucceeded, session, secondProject, mojo));
+            profiler.onEvent(event(ExecutionEvent.Type.ProjectSucceeded, session, secondProject, null));
+            profiler.onEvent(event(ExecutionEvent.Type.SessionEnded, session, null, null));
+            profiler.close();
+
+            List<String> lines = Files.readAllLines(timeline, StandardCharsets.UTF_8);
+            assertEquals(8, lines.size());
+            assertTrue(lines.get(0).contains("\"event\":\"SessionStarted\""));
+            assertTrue(lines.get(1).contains("\"project\":\"g:first:1\""));
+            assertTrue(lines.get(2).contains("\"project\":\"g:second:1\""));
+            assertTrue(lines.get(2).contains("\"upstreamProjects\":[\"g:first:1\"]"));
+            assertTrue(lines.get(4).contains("\"event\":\"MojoStarted\""));
+            assertTrue(lines.get(4).contains("\"executionId\":\"default-test\""));
+            assertTrue(lines.get(4).contains("\"lifecyclePhase\":\"test\""));
+            assertNull(renderer.profile);
+        } finally {
+            Files.deleteIfExists(timeline);
+            restoreProperty("maven.profile", oldProfile);
+        }
+    }
+
+    public void testTimelineCanBeDisabledExplicitly() {
+        String oldTimeline = System.getProperty(TimelineRecorder.TIMELINE_PROPERTY);
+        System.setProperty(TimelineRecorder.TIMELINE_PROPERTY, "false");
+        try {
+            assertFalse(new TimelineRecorder().isEnabled());
+        } finally {
+            restoreProperty(TimelineRecorder.TIMELINE_PROPERTY, oldTimeline);
+        }
+    }
+
     protected MavenProject project(String g, String a, String v) {
         MavenProject p = new MavenProject();
         p.setGroupId(g);
@@ -61,11 +168,123 @@ public class LifecycleProfilerTest extends InjectedTestCase {
     }
 
     protected MojoExecution mojoExecution(String goal, String executionId) {
+        return mojoExecution(goal, executionId, null);
+    }
+
+    protected MojoExecution mojoExecution(String goal, String executionId, String lifecyclePhase) {
         Plugin p = new Plugin();
         p.setGroupId("groupId");
         p.setArtifactId("artifactId");
         p.setVersion("version");
         MojoExecution me = new MojoExecution(p, goal, executionId);
+        me.setLifecyclePhase(lifecyclePhase);
         return me;
+    }
+
+    private static MavenSession session(MavenProject... projects) {
+        DefaultMavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.setGoals(Collections.singletonList("verify"));
+        return new MavenSession(null, request, new DefaultMavenExecutionResult(), Arrays.asList(projects));
+    }
+
+    private static ProjectDependencyGraph graph(MavenProject firstProject, MavenProject secondProject) {
+        List<MavenProject> projects = Arrays.asList(firstProject, secondProject);
+        return new ProjectDependencyGraph() {
+            @Override
+            public List<MavenProject> getAllProjects() {
+                return projects;
+            }
+
+            @Override
+            public List<MavenProject> getSortedProjects() {
+                return projects;
+            }
+
+            @Override
+            public List<MavenProject> getDownstreamProjects(MavenProject project, boolean transitive) {
+                return project == firstProject ? Collections.singletonList(secondProject) : Collections.emptyList();
+            }
+
+            @Override
+            public List<MavenProject> getUpstreamProjects(MavenProject project, boolean transitive) {
+                return project == secondProject ? Collections.singletonList(firstProject) : Collections.emptyList();
+            }
+        };
+    }
+
+    private static void profileProject(
+            LifecycleProfiler profiler,
+            MavenSession session,
+            MavenProject project,
+            MojoExecution mojo,
+            CyclicBarrier barrier) {
+        try {
+            profiler.onEvent(event(ExecutionEvent.Type.ProjectStarted, session, project, null));
+            barrier.await();
+            profiler.onEvent(event(ExecutionEvent.Type.MojoStarted, session, project, mojo));
+            barrier.await();
+            profiler.onEvent(event(ExecutionEvent.Type.MojoSucceeded, session, project, mojo));
+            barrier.await();
+            profiler.onEvent(event(ExecutionEvent.Type.ProjectSucceeded, session, project, null));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void assertProjectProfile(
+            ProjectProfile projectProfile, String projectName, String phase, String executionId) {
+        assertEquals(projectName, projectProfile.getProjectName());
+        assertEquals(1, projectProfile.getPhaseProfile().size());
+        PhaseProfile phaseProfile = projectProfile.getPhaseProfile().get(0);
+        assertEquals(phase, phaseProfile.getPhase());
+        assertEquals(1, phaseProfile.getMojoProfiles().size());
+        assertTrue(phaseProfile.getMojoProfiles().get(0).getId().contains("(" + executionId + ")"));
+    }
+
+    private static ExecutionEvent event(
+            ExecutionEvent.Type type, MavenSession session, MavenProject project, MojoExecution mojoExecution) {
+        return new ExecutionEvent() {
+            @Override
+            public Type getType() {
+                return type;
+            }
+
+            @Override
+            public MavenSession getSession() {
+                return session;
+            }
+
+            @Override
+            public MavenProject getProject() {
+                return project;
+            }
+
+            @Override
+            public MojoExecution getMojoExecution() {
+                return mojoExecution;
+            }
+
+            @Override
+            public Exception getException() {
+                return null;
+            }
+        };
+    }
+
+    private static void restoreProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    private static final class CapturingRenderer implements SessionProfileRenderer {
+        private SessionProfile profile;
+
+        @Override
+        public void render(SessionProfile sessionProfile) {
+            profile = sessionProfile;
+        }
     }
 }

--- a/src/test/java/io/tesla/lifecycle/profiler/internal/TimerTest.java
+++ b/src/test/java/io/tesla/lifecycle/profiler/internal/TimerTest.java
@@ -29,4 +29,15 @@ public class TimerTest {
     public void assertDetailLoss() {
         Assert.assertEquals("1m 1s", DefaultTimer.formatMilliseconds(61 * MS_PER_SEC + 1));
     }
+
+    @Test
+    public void booleanPropertyCanDisableOutput() {
+        String property = "maven.profile.test.boolean";
+        System.setProperty(property, "false");
+        try {
+            Assert.assertFalse(AbstractSessionProfileRenderer.getBooleanProperty(property, true));
+        } finally {
+            System.clearProperty(property);
+        }
+    }
 }


### PR DESCRIPTION
## What changed

- isolate project, phase, and mojo profiling state per Maven project so aggregate profiling works under parallel reactors
- render aggregate projects in deterministic reactor order
- add an opt-in schema-versioned JSONL timeline with wall and monotonic timestamps, Maven builder-thread identity, project/mojo events, and reactor dependency edges
- allow timeline capture independently of aggregate profiling
- correct explicit `false` and `no` boolean-property handling
- remove the inherited Palantir Java formatter while retaining import and POM checks

## Why

The released profiler stores the current project, phase, and mojo in singleton mutable fields. Maven invokes one EventSpy concurrently from multiple builder threads under `-T`, so events from different projects overwrite that shared state. A controlled `-T2` reactor reproduced crossed project records, duplicated aggregates, impossible durations, and an EventSpy state warning.

Aggregate durations alone also cannot reconstruct lifecycle overlap. The raw timeline preserves the public Maven execution events and dependency graph needed to analyze reactor scheduling. Maven does not expose a formal project-ready or scheduler-queue event, so readiness remains a derived value rather than an observed one.

## Validation

- `./mvnw clean package`: 7 tests passed on JDK 25
- effective POM contains no `palantirJavaFormat`
- sequential Maven 3.9.11 miniature reactor: success, 83 valid JSONL records, four correct projects
- `-T2` miniature reactor: success, 83 valid JSONL records, distinct builder threads, correct dependency edges, no crossed aggregate state or EventSpy warning
- focused Airship run: 18 tests passed with two Surefire forks, 44 Maven timeline records, two Open Test reports, two bounded JFR recordings, and legacy Surefire XML

The Airship run proves compatibility of the observability stack; it is not a performance comparison.
